### PR TITLE
fix bug in clip function

### DIFF
--- a/vesc_driver/src/vesc_driver.cpp
+++ b/vesc_driver/src/vesc_driver.cpp
@@ -288,6 +288,7 @@ double VescDriver::CommandLimit::clip(double value)
                       name.c_str(), value, *upper);
     return *upper;
   }
+  return value;
 }
 
 


### PR DESCRIPTION
The VescDriver::CommandLimit::clip function is meant to ensure that a given value is within the correct range.

Previously it would only return a value if that value was clipped. It now returns the original value if it is not clipped.

We found this bug when the servo and speed commands would only work at the high and low points (using a joystick teleop). With this fix, the servo and speed commands have a full variable range.
